### PR TITLE
Remove default root password from Conversion VM

### DIFF
--- a/extras/conversion-vm/centos.ks
+++ b/extras/conversion-vm/centos.ks
@@ -2,8 +2,7 @@ lang en_US
 keyboard us
 timezone America/New_York --isUtc
 
-# default credentials are root / 123456
-rootpw $1$079LKObj$MU35vtfsQLMxw1jcaINpu/ --iscrypted
+rootpw --lock
 
 #platform x86, AMD64, or Intel EM64T
 reboot

--- a/extras/conversion-vm/rhel.ks
+++ b/extras/conversion-vm/rhel.ks
@@ -2,8 +2,7 @@ lang en_US
 keyboard us
 timezone America/New_York --isUtc
 
-# default credentials are root / 123456
-rootpw $1$079LKObj$MU35vtfsQLMxw1jcaINpu/ --iscrypted
+rootpw --lock
 
 #platform x86, AMD64, or Intel EM64T
 reboot


### PR DESCRIPTION
Conversion VM build scripts for OpenStack should not contain working root
password for security reasons. Root account is now locked by default.