### PR TITLE
Fix package paths after project move

### DIFF
--- a/kubevirt-vmware/build/Dockerfile
+++ b/kubevirt-vmware/build/Dockerfile
@@ -1,11 +1,11 @@
 FROM alpine:3.8
 
-ENV OPERATOR=/usr/local/bin/v2v-vmware \
+ENV OPERATOR=/usr/local/bin/kubevirt-vmware \
     USER_UID=1001 \
-    USER_NAME=v2v-vmware
+    USER_NAME=kubevirt-vmware
 
 # install operator binary
-COPY build/_output/bin/v2v-vmware ${OPERATOR}
+COPY build/_output/bin/kubevirt-vmware ${OPERATOR}
 
 COPY build/bin /usr/local/bin
 RUN  /usr/local/bin/user_setup

--- a/kubevirt-vmware/build/bin/entrypoint
+++ b/kubevirt-vmware/build/bin/entrypoint
@@ -5,7 +5,7 @@
 
 if ! whoami &>/dev/null; then
   if [ -w /etc/passwd ]; then
-    echo "${USER_NAME:-v2v-vmware}:x:$(id -u):$(id -g):${USER_NAME:-v2v-vmware} user:${HOME}:/sbin/nologin" >> /etc/passwd
+    echo "${USER_NAME:-kubevirt-vmware}:x:$(id -u):$(id -g):${USER_NAME:-kubevirt-vmware} user:${HOME}:/sbin/nologin" >> /etc/passwd
   fi
 fi
 

--- a/kubevirt-vmware/cmd/manager/main.go
+++ b/kubevirt-vmware/cmd/manager/main.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"runtime"
 
-	"kubevirt.io/v2v-vmware/pkg/apis"
-	"kubevirt.io/v2v-vmware/pkg/controller"
+	"github.com/ovirt/v2v-conversion-host/kubevirt-vmware/pkg/apis"
+	"github.com/ovirt/v2v-conversion-host/kubevirt-vmware/pkg/controller"
 
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	"github.com/operator-framework/operator-sdk/pkg/leader"

--- a/kubevirt-vmware/pkg/apis/addtoscheme_kubevirt_v1alpha1.go
+++ b/kubevirt-vmware/pkg/apis/addtoscheme_kubevirt_v1alpha1.go
@@ -1,7 +1,7 @@
 package apis
 
 import (
-	"kubevirt.io/v2v-vmware/pkg/apis/kubevirt/v1alpha1"
+	"github.com/ovirt/v2v-conversion-host/kubevirt-vmware/pkg/apis/kubevirt/v1alpha1"
 )
 
 func init() {

--- a/kubevirt-vmware/pkg/apis/kubevirt/v1alpha1/zz_generated.openapi.go
+++ b/kubevirt-vmware/pkg/apis/kubevirt/v1alpha1/zz_generated.openapi.go
@@ -13,9 +13,9 @@ import (
 
 func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenAPIDefinition {
 	return map[string]common.OpenAPIDefinition{
-		"kubevirt.io/v2v-vmware/pkg/apis/kubevirt/v1alpha1.V2VVmware":       schema_pkg_apis_kubevirt_v1alpha1_V2VVmware(ref),
-		"kubevirt.io/v2v-vmware/pkg/apis/kubevirt/v1alpha1.V2VVmwareSpec":   schema_pkg_apis_kubevirt_v1alpha1_V2VVmwareSpec(ref),
-		"kubevirt.io/v2v-vmware/pkg/apis/kubevirt/v1alpha1.V2VVmwareStatus": schema_pkg_apis_kubevirt_v1alpha1_V2VVmwareStatus(ref),
+		"github.com/ovirt/v2v-conversion-host/kubevirt-vmware/pkg/apis/kubevirt/v1alpha1.V2VVmware":       schema_pkg_apis_kubevirt_v1alpha1_V2VVmware(ref),
+		"github.com/ovirt/v2v-conversion-host/kubevirt-vmware/pkg/apis/kubevirt/v1alpha1.V2VVmwareSpec":   schema_pkg_apis_kubevirt_v1alpha1_V2VVmwareSpec(ref),
+		"github.com/ovirt/v2v-conversion-host/kubevirt-vmware/pkg/apis/kubevirt/v1alpha1.V2VVmwareStatus": schema_pkg_apis_kubevirt_v1alpha1_V2VVmwareStatus(ref),
 	}
 }
 
@@ -46,19 +46,19 @@ func schema_pkg_apis_kubevirt_v1alpha1_V2VVmware(ref common.ReferenceCallback) c
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("kubevirt.io/v2v-vmware/pkg/apis/kubevirt/v1alpha1.V2VVmwareSpec"),
+							Ref: ref("github.com/ovirt/v2v-conversion-host/kubevirt-vmware/pkg/apis/kubevirt/v1alpha1.V2VVmwareSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("kubevirt.io/v2v-vmware/pkg/apis/kubevirt/v1alpha1.V2VVmwareStatus"),
+							Ref: ref("github.com/ovirt/v2v-conversion-host/kubevirt-vmware/pkg/apis/kubevirt/v1alpha1.V2VVmwareStatus"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta", "kubevirt.io/v2v-vmware/pkg/apis/kubevirt/v1alpha1.V2VVmwareSpec", "kubevirt.io/v2v-vmware/pkg/apis/kubevirt/v1alpha1.V2VVmwareStatus"},
+			"k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta", "github.com/ovirt/v2v-conversion-host/kubevirt-vmware/pkg/apis/kubevirt/v1alpha1.V2VVmwareSpec", "github.com/ovirt/v2v-conversion-host/kubevirt-vmware/pkg/apis/kubevirt/v1alpha1.V2VVmwareStatus"},
 	}
 }
 

--- a/kubevirt-vmware/pkg/controller/add_v2vvmware.go
+++ b/kubevirt-vmware/pkg/controller/add_v2vvmware.go
@@ -1,7 +1,7 @@
 package controller
 
 import (
-	"kubevirt.io/v2v-vmware/pkg/controller/v2vvmware"
+	"github.com/ovirt/v2v-conversion-host/kubevirt-vmware/pkg/controller/v2vvmware"
 )
 
 func init() {

--- a/kubevirt-vmware/pkg/controller/v2vvmware/actions.go
+++ b/kubevirt-vmware/pkg/controller/v2vvmware/actions.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 	corev1 "k8s.io/api/core/v1"
-	kubevirtv1alpha1 "kubevirt.io/v2v-vmware/pkg/apis/kubevirt/v1alpha1"
+	kubevirtv1alpha1 "github.com/ovirt/v2v-conversion-host/kubevirt-vmware/pkg/apis/kubevirt/v1alpha1"
 	"time"
 
 	"k8s.io/apimachinery/pkg/types"

--- a/kubevirt-vmware/pkg/controller/v2vvmware/v2vvmware_controller.go
+++ b/kubevirt-vmware/pkg/controller/v2vvmware/v2vvmware_controller.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	kubevirtv1alpha1 "kubevirt.io/v2v-vmware/pkg/apis/kubevirt/v1alpha1"
+	kubevirtv1alpha1 "github.com/ovirt/v2v-conversion-host/kubevirt-vmware/pkg/apis/kubevirt/v1alpha1"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/kubevirt-vmware/pkg/controller/v2vvmware/vmware.go
+++ b/kubevirt-vmware/pkg/controller/v2vvmware/vmware.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	kubevirtv1alpha1 "kubevirt.io/v2v-vmware/pkg/apis/kubevirt/v1alpha1"
+	kubevirtv1alpha1 "github.com/ovirt/v2v-conversion-host/kubevirt-vmware/pkg/apis/kubevirt/v1alpha1"
 )
 
 /*


### PR DESCRIPTION
The project is not fully renamed from `v2v-vmware` to `kubevirt-vmware` yet.
But can be built for now.