### PR TITLE
Add garbage collector for kubevirt-vmware

### DIFF
--- a/kubevirt-vmware/build/Dockerfile
+++ b/kubevirt-vmware/build/Dockerfile
@@ -1,11 +1,11 @@
 FROM alpine:3.8
 
-ENV OPERATOR=/usr/local/bin/v2v-vmware \
+ENV OPERATOR=/usr/local/bin/kubevirt-vmware \
     USER_UID=1001 \
-    USER_NAME=v2v-vmware
+    USER_NAME=kubevirt-vmware
 
 # install operator binary
-COPY build/_output/bin/v2v-vmware ${OPERATOR}
+COPY build/_output/bin/kubevirt-vmware ${OPERATOR}
 
 COPY build/bin /usr/local/bin
 RUN  /usr/local/bin/user_setup

--- a/kubevirt-vmware/build/bin/entrypoint
+++ b/kubevirt-vmware/build/bin/entrypoint
@@ -5,7 +5,7 @@
 
 if ! whoami &>/dev/null; then
   if [ -w /etc/passwd ]; then
-    echo "${USER_NAME:-v2v-vmware}:x:$(id -u):$(id -g):${USER_NAME:-v2v-vmware} user:${HOME}:/sbin/nologin" >> /etc/passwd
+    echo "${USER_NAME:-kubevirt-vmware}:x:$(id -u):$(id -g):${USER_NAME:-kubevirt-vmware} user:${HOME}:/sbin/nologin" >> /etc/passwd
   fi
 fi
 

--- a/kubevirt-vmware/cmd/manager/main.go
+++ b/kubevirt-vmware/cmd/manager/main.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"runtime"
 
-	"kubevirt.io/v2v-vmware/pkg/apis"
-	"kubevirt.io/v2v-vmware/pkg/controller"
+	"github.com/ovirt/v2v-conversion-host/kubevirt-vmware/pkg/apis"
+	"github.com/ovirt/v2v-conversion-host/kubevirt-vmware/pkg/controller"
 
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	"github.com/operator-framework/operator-sdk/pkg/leader"

--- a/kubevirt-vmware/pkg/apis/addtoscheme_kubevirt_v1alpha1.go
+++ b/kubevirt-vmware/pkg/apis/addtoscheme_kubevirt_v1alpha1.go
@@ -1,7 +1,7 @@
 package apis
 
 import (
-	"kubevirt.io/v2v-vmware/pkg/apis/kubevirt/v1alpha1"
+	"github.com/ovirt/v2v-conversion-host/kubevirt-vmware/pkg/apis/kubevirt/v1alpha1"
 )
 
 func init() {

--- a/kubevirt-vmware/pkg/apis/kubevirt/v1alpha1/v2vvmware_types.go
+++ b/kubevirt-vmware/pkg/apis/kubevirt/v1alpha1/v2vvmware_types.go
@@ -22,6 +22,7 @@ type VmwareVm struct {
 // +k8s:openapi-gen=true
 type V2VVmwareSpec struct {
     Connection string `json:"connection,omitempty"` // name of Secret wit vmware connection details
+    TimeToLive string `json:"timeToLive,omitempty"` // for custom garbage collector
     Vms []VmwareVm `json:"vms,omitempty"`
 }
 

--- a/kubevirt-vmware/pkg/apis/kubevirt/v1alpha1/zz_generated.openapi.go
+++ b/kubevirt-vmware/pkg/apis/kubevirt/v1alpha1/zz_generated.openapi.go
@@ -13,9 +13,9 @@ import (
 
 func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenAPIDefinition {
 	return map[string]common.OpenAPIDefinition{
-		"kubevirt.io/v2v-vmware/pkg/apis/kubevirt/v1alpha1.V2VVmware":       schema_pkg_apis_kubevirt_v1alpha1_V2VVmware(ref),
-		"kubevirt.io/v2v-vmware/pkg/apis/kubevirt/v1alpha1.V2VVmwareSpec":   schema_pkg_apis_kubevirt_v1alpha1_V2VVmwareSpec(ref),
-		"kubevirt.io/v2v-vmware/pkg/apis/kubevirt/v1alpha1.V2VVmwareStatus": schema_pkg_apis_kubevirt_v1alpha1_V2VVmwareStatus(ref),
+		"github.com/ovirt/v2v-conversion-host/kubevirt-vmware/pkg/apis/kubevirt/v1alpha1.V2VVmware":       schema_pkg_apis_kubevirt_v1alpha1_V2VVmware(ref),
+		"github.com/ovirt/v2v-conversion-host/kubevirt-vmware/pkg/apis/kubevirt/v1alpha1.V2VVmwareSpec":   schema_pkg_apis_kubevirt_v1alpha1_V2VVmwareSpec(ref),
+		"github.com/ovirt/v2v-conversion-host/kubevirt-vmware/pkg/apis/kubevirt/v1alpha1.V2VVmwareStatus": schema_pkg_apis_kubevirt_v1alpha1_V2VVmwareStatus(ref),
 	}
 }
 
@@ -46,19 +46,19 @@ func schema_pkg_apis_kubevirt_v1alpha1_V2VVmware(ref common.ReferenceCallback) c
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("kubevirt.io/v2v-vmware/pkg/apis/kubevirt/v1alpha1.V2VVmwareSpec"),
+							Ref: ref("github.com/ovirt/v2v-conversion-host/kubevirt-vmware/pkg/apis/kubevirt/v1alpha1.V2VVmwareSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("kubevirt.io/v2v-vmware/pkg/apis/kubevirt/v1alpha1.V2VVmwareStatus"),
+							Ref: ref("github.com/ovirt/v2v-conversion-host/kubevirt-vmware/pkg/apis/kubevirt/v1alpha1.V2VVmwareStatus"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta", "kubevirt.io/v2v-vmware/pkg/apis/kubevirt/v1alpha1.V2VVmwareSpec", "kubevirt.io/v2v-vmware/pkg/apis/kubevirt/v1alpha1.V2VVmwareStatus"},
+			"k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta", "github.com/ovirt/v2v-conversion-host/kubevirt-vmware/pkg/apis/kubevirt/v1alpha1.V2VVmwareSpec", "github.com/ovirt/v2v-conversion-host/kubevirt-vmware/pkg/apis/kubevirt/v1alpha1.V2VVmwareStatus"},
 	}
 }
 

--- a/kubevirt-vmware/pkg/controller/add_v2vvmware.go
+++ b/kubevirt-vmware/pkg/controller/add_v2vvmware.go
@@ -1,7 +1,7 @@
 package controller
 
 import (
-	"kubevirt.io/v2v-vmware/pkg/controller/v2vvmware"
+	"github.com/ovirt/v2v-conversion-host/kubevirt-vmware/pkg/controller/v2vvmware"
 )
 
 func init() {

--- a/kubevirt-vmware/pkg/controller/add_v2vvmware.go
+++ b/kubevirt-vmware/pkg/controller/add_v2vvmware.go
@@ -2,10 +2,11 @@ package controller
 
 import (
 	"github.com/ovirt/v2v-conversion-host/kubevirt-vmware/pkg/controller/v2vvmware"
+	gc "github.com/ovirt/v2v-conversion-host/kubevirt-vmware/pkg/controller/garbage_collector"
 )
 
 func init() {
 	// AddToManagerFuncs is a list of functions to create controllers and add them to a manager.
 	AddToManagerFuncs = append(AddToManagerFuncs, v2vvmware.Add)
-	// TODO: register Garbage Collector controller
+	AddToManagerFuncs = append(AddToManagerFuncs, gc.GC)
 }

--- a/kubevirt-vmware/pkg/controller/garbage_collector/v2vvmware_garbagecollector.go
+++ b/kubevirt-vmware/pkg/controller/garbage_collector/v2vvmware_garbagecollector.go
@@ -1,0 +1,130 @@
+package garbage_collector
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/ovirt/v2v-conversion-host/kubevirt-vmware/pkg/controller/utils"
+
+	kubevirtv1alpha1 "github.com/ovirt/v2v-conversion-host/kubevirt-vmware/pkg/apis/kubevirt/v1alpha1"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+const vCenterTemporaryLabel = "cnv.io/temporary"
+
+var log = logf.Log.WithName("gc_v2vvmware")
+
+// GC creates a new V2VVmware Garbage Collector (controller) and adds it to the Manager. The Manager will set fields on the Controller
+// and Start it when the Manager is Started.
+func GC(mgr manager.Manager) error {
+	return addGc(mgr, newReconciler(mgr))
+}
+
+// newReconciler returns a new reconcile.Reconciler
+func newReconciler(mgr manager.Manager) reconcile.Reconciler {
+	return &ReconcileV2VVmware{client: mgr.GetClient(), scheme: mgr.GetScheme()}
+}
+
+// add adds a new Controller to mgr with r as the reconcile.Reconciler
+func addGc(mgr manager.Manager, r reconcile.Reconciler) error {
+	// Create a new controller
+	c, err := controller.New("v2v-vmware-garbage-collector", mgr, controller.Options{Reconciler: r})
+	if err != nil {
+		return err
+	}
+
+	// Watch for changes to primary resource V2VVmware
+	err = c.Watch(&source.Kind{Type: &kubevirtv1alpha1.V2VVmware{}}, &handler.EnqueueRequestForObject{})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var _ reconcile.Reconciler = &ReconcileV2VVmware{}
+
+type ReconcileV2VVmware struct {
+	client client.Client
+	scheme *runtime.Scheme
+}
+
+func (r *ReconcileV2VVmware) updateDeletionTimestamp(namespacedName types.NamespacedName, valueTime time.Time, counter int) error {
+	value := valueTime.Format(time.RFC3339)
+	obj := &kubevirtv1alpha1.V2VVmware{}
+	err := r.client.Get(context.TODO(), namespacedName, obj) // get fresh copy
+	if err != nil {
+		if counter > 0 {
+			utils.SleepBeforeRetry()
+			return r.updateDeletionTimestamp(namespacedName, valueTime, counter - 1)
+		}
+		return err
+	}
+
+	obj.Spec.TimeToLive = value
+	err = r.client.Update(context.TODO(), obj)
+	if err != nil {
+		log.Error(err, fmt.Sprintf("Failed to update V2VVmware timeToLive. Intended to write: '%s'", value))
+		if counter > 0 {
+			utils.SleepBeforeRetry()
+			return r.updateDeletionTimestamp(namespacedName, valueTime, counter - 1)
+		}
+	}
+	return nil
+}
+
+func (r *ReconcileV2VVmware) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
+	reqLogger.Info("V2VVmware Garbage Collector")
+
+	result := reconcile.Result{} // no requeue
+	reschedule := reconcile.Result{RequeueAfter: time.Second*5} // TODO: increase
+
+	opts := &client.ListOptions{
+		Namespace:request.Namespace,
+	}
+
+	v2vvmwares := &kubevirtv1alpha1.V2VVmwareList{}
+	err := r.client.List(context.TODO(), opts, v2vvmwares)
+	if err != nil {
+		reqLogger.Error(err, "Failed to get list of temporary V2VVMWare objects.")
+		return reconcile.Result{RequeueAfter: time.Second*5}, nil // schedule next GC round
+	}
+
+	log.Info(fmt.Sprintf("List of V2VVMWare objects retrieved, count: %d", len(v2vvmwares.Items)))
+	for _, obj := range v2vvmwares.Items {
+		if len(obj.Spec.TimeToLive) > 0 { // timeToLive is set
+			result = reschedule
+			reqLogger.Info(fmt.Sprintf("Object with timeToLive found, name = '%s', value = '%s', now = '%s'", obj.Name, obj.Spec.TimeToLive, time.Now().Format(time.RFC3339)))
+			timeToLive, _ := time.Parse(time.RFC3339, obj.Spec.TimeToLive)
+
+			if time.Now().After(timeToLive) {
+				reqLogger.Info(fmt.Sprintf("Time to live is gone for V2VVmware object '%s', ttl = '%s'. Will be removed", obj.Name, obj.Spec.TimeToLive))
+				err = r.client.Delete(context.TODO(), &obj) // if failed now, it will be deleted next time
+				if err != nil {
+					reqLogger.Error(err, fmt.Sprintf("Failed to remove V2VVmware object '%s' after time out, will be scheduled for next round.", obj.Name))
+				}
+			}
+		} else if obj.Labels[vCenterTemporaryLabel] == "true" {
+			result = reschedule
+			reqLogger.Info(fmt.Sprintf("Object with vCenterTemporaryLabel label found, name = '%s'. TimeToLive will be set.", obj.Name))
+			deletionTimeStamp := obj.CreationTimestamp.Time.Add(time.Second * 20)
+			err := r.updateDeletionTimestamp(types.NamespacedName{Name: obj.Name, Namespace: obj.Namespace}, deletionTimeStamp, utils.MaxRetryCount)
+			if err != nil {
+				reqLogger.Info(fmt.Sprintf("Permanently failed to update timeToLive of '%s'", obj.Name))
+				// ignore and continue with remaining objects
+			}
+		}
+	}
+	return result, nil // schedule potentially next GC round
+}

--- a/kubevirt-vmware/pkg/controller/garbage_collector/v2vvmware_garbagecollector.go
+++ b/kubevirt-vmware/pkg/controller/garbage_collector/v2vvmware_garbagecollector.go
@@ -5,11 +5,14 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/ovirt/v2v-conversion-host/kubevirt-vmware/pkg/controller/utils"
+	corev1 "k8s.io/api/core/v1"
 
 	kubevirtv1alpha1 "github.com/ovirt/v2v-conversion-host/kubevirt-vmware/pkg/apis/kubevirt/v1alpha1"
+	"github.com/ovirt/v2v-conversion-host/kubevirt-vmware/pkg/controller/utils"
 
+	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -17,10 +20,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/source"
-	"k8s.io/apimachinery/pkg/types"
 )
 
 const vCenterTemporaryLabel = "cnv.io/temporary"
+
+const DefaultTimeToLiveDuration = time.Second * 20 // TODO: increase
+
+var doneResult = reconcile.Result{} // no requeue
+var rescheduleResult = reconcile.Result{RequeueAfter: time.Second*5} // TODO: increase
 
 var log = logf.Log.WithName("gc_v2vvmware")
 
@@ -62,7 +69,7 @@ type ReconcileV2VVmware struct {
 func (r *ReconcileV2VVmware) updateDeletionTimestamp(namespacedName types.NamespacedName, valueTime time.Time, counter int) error {
 	value := valueTime.Format(time.RFC3339)
 	obj := &kubevirtv1alpha1.V2VVmware{}
-	err := r.client.Get(context.TODO(), namespacedName, obj) // get fresh copy
+	err := r.client.Get(context.TODO(), namespacedName, obj) // get a fresh copy
 	if err != nil {
 		if counter > 0 {
 			utils.SleepBeforeRetry()
@@ -83,28 +90,49 @@ func (r *ReconcileV2VVmware) updateDeletionTimestamp(namespacedName types.Namesp
 	return nil
 }
 
-func (r *ReconcileV2VVmware) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
-	reqLogger.Info("V2VVmware Garbage Collector")
+func (r *ReconcileV2VVmware) updateSecretDeletionTimestamp(namespacedName types.NamespacedName, valueTime time.Time, counter int) error {
+	value := valueTime.Format(time.RFC3339)
+	obj := &corev1.Secret{}
+	err := r.client.Get(context.TODO(), namespacedName, obj) // get a fresh copy
+	if err != nil {
+		if counter > 0 {
+			utils.SleepBeforeRetry()
+			return r.updateSecretDeletionTimestamp(namespacedName, valueTime, counter - 1)
+		}
+		return err
+	}
 
-	result := reconcile.Result{} // no requeue
-	reschedule := reconcile.Result{RequeueAfter: time.Second*5} // TODO: increase
+	obj.Data["timeToLive"] = []byte(value)
+	err = r.client.Update(context.TODO(), obj)
+	if err != nil {
+		log.Error(err, fmt.Sprintf("Failed to update Secret timeToLive. Intended to write: '%s'", value))
+		if counter > 0 {
+			utils.SleepBeforeRetry()
+			return r.updateSecretDeletionTimestamp(namespacedName, valueTime, counter - 1)
+		}
+	}
+	return nil
+}
+
+
+func (r *ReconcileV2VVmware) pruneV2VVMwares(reqLogger logr.Logger, namespace string ) reconcile.Result {
+	result := doneResult
 
 	opts := &client.ListOptions{
-		Namespace:request.Namespace,
+		Namespace: namespace,
 	}
 
 	v2vvmwares := &kubevirtv1alpha1.V2VVmwareList{}
 	err := r.client.List(context.TODO(), opts, v2vvmwares)
 	if err != nil {
 		reqLogger.Error(err, "Failed to get list of temporary V2VVMWare objects.")
-		return reconcile.Result{RequeueAfter: time.Second*5}, nil // schedule next GC round
+		return rescheduleResult
 	}
 
 	log.Info(fmt.Sprintf("List of V2VVMWare objects retrieved, count: %d", len(v2vvmwares.Items)))
 	for _, obj := range v2vvmwares.Items {
 		if len(obj.Spec.TimeToLive) > 0 { // timeToLive is set
-			result = reschedule
+			result = rescheduleResult
 			reqLogger.Info(fmt.Sprintf("Object with timeToLive found, name = '%s', value = '%s', now = '%s'", obj.Name, obj.Spec.TimeToLive, time.Now().Format(time.RFC3339)))
 			timeToLive, _ := time.Parse(time.RFC3339, obj.Spec.TimeToLive)
 
@@ -116,15 +144,77 @@ func (r *ReconcileV2VVmware) Reconcile(request reconcile.Request) (reconcile.Res
 				}
 			}
 		} else if obj.Labels[vCenterTemporaryLabel] == "true" {
-			result = reschedule
-			reqLogger.Info(fmt.Sprintf("Object with vCenterTemporaryLabel label found, name = '%s'. TimeToLive will be set.", obj.Name))
-			deletionTimeStamp := obj.CreationTimestamp.Time.Add(time.Second * 20)
+			result = rescheduleResult
+			reqLogger.Info(fmt.Sprintf("V2VVMware with '%s' label found, name = '%s'. TimeToLive will be set.", vCenterTemporaryLabel, obj.Name))
+			deletionTimeStamp := obj.CreationTimestamp.Time.Add(DefaultTimeToLiveDuration)
 			err := r.updateDeletionTimestamp(types.NamespacedName{Name: obj.Name, Namespace: obj.Namespace}, deletionTimeStamp, utils.MaxRetryCount)
 			if err != nil {
-				reqLogger.Info(fmt.Sprintf("Permanently failed to update timeToLive of '%s'", obj.Name))
+				reqLogger.Info(fmt.Sprintf("Permanently failed to update timeToLive of '%s' V2VVMWare", obj.Name))
 				// ignore and continue with remaining objects
 			}
 		}
 	}
+
+	return result
+}
+
+
+func (r *ReconcileV2VVmware) pruneSecrets(reqLogger logr.Logger, namespace string ) reconcile.Result {
+	result := doneResult
+
+	opts := &client.ListOptions{
+		Namespace: namespace,
+	}
+
+	secrets := &corev1.SecretList{}
+	err := r.client.List(context.TODO(), opts, secrets)
+	if err != nil {
+		reqLogger.Error(err, "Failed to get list of temporary Secret objects.")
+		return rescheduleResult
+	}
+
+	log.Info(fmt.Sprintf("List of Secret objects retrieved, count: %d", len(secrets.Items)))
+	for _, obj := range secrets.Items {
+		timeToLiveStr := string(obj.Data["timeToLive"])
+		if len(timeToLiveStr) > 0 { // timeToLive is set
+			result = rescheduleResult
+			reqLogger.Info(fmt.Sprintf("Secret with timeToLive found, name = '%s', value = '%s', now = '%s'", obj.Name, timeToLiveStr, time.Now().Format(time.RFC3339)))
+			timeToLive, _ := time.Parse(time.RFC3339, timeToLiveStr)
+
+			if time.Now().After(timeToLive) {
+				reqLogger.Info(fmt.Sprintf("Time to live is gone for Secret object '%s', ttl = '%s'. Will be removed", obj.Name, timeToLiveStr))
+				err = r.client.Delete(context.TODO(), &obj) // if failed now, it will be deleted next time
+				if err != nil {
+					reqLogger.Error(err, fmt.Sprintf("Failed to remove Secret object '%s' after time out, will be scheduled for next round.", obj.Name))
+				}
+			}
+		} else if obj.Labels[vCenterTemporaryLabel] == "true" {
+			result = rescheduleResult
+			reqLogger.Info(fmt.Sprintf("Secret with '%s' label found, name = '%s'. TimeToLive will be set.", vCenterTemporaryLabel, obj.Name))
+			deletionTimeStamp := obj.CreationTimestamp.Time.Add(DefaultTimeToLiveDuration)
+			err := r.updateSecretDeletionTimestamp(types.NamespacedName{Name: obj.Name, Namespace: obj.Namespace}, deletionTimeStamp, utils.MaxRetryCount)
+			if err != nil {
+				reqLogger.Info(fmt.Sprintf("Permanently failed to update timeToLive of '%s' Secret", obj.Name))
+				// ignore and continue with remaining objects
+			}
+		}
+	}
+
+	return result
+}
+
+
+func (r *ReconcileV2VVmware) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
+	reqLogger.Info("V2VVmware Garbage Collector")
+
+	resultV2VVMWares := r.pruneV2VVMwares(reqLogger, request.Namespace)
+	resultSecrets := r.pruneSecrets(reqLogger, request.Namespace)
+
+	result := resultV2VVMWares
+	if result == doneResult {
+		result = resultSecrets
+	}
+
 	return result, nil // schedule potentially next GC round
 }

--- a/kubevirt-vmware/pkg/controller/garbage_collector/v2vvmware_garbagecollector.go
+++ b/kubevirt-vmware/pkg/controller/garbage_collector/v2vvmware_garbagecollector.go
@@ -24,10 +24,10 @@ import (
 
 const vCenterTemporaryLabel = "cnv.io/temporary"
 
-const DefaultTimeToLiveDuration = time.Second * 20 // TODO: increase
+const DefaultTimeToLiveDuration = time.Hour * 1
 
 var doneResult = reconcile.Result{} // no requeue
-var rescheduleResult = reconcile.Result{RequeueAfter: time.Second*5} // TODO: increase
+var rescheduleResult = reconcile.Result{RequeueAfter: time.Minute*5}
 
 var log = logf.Log.WithName("gc_v2vvmware")
 

--- a/kubevirt-vmware/pkg/controller/utils/utils.go
+++ b/kubevirt-vmware/pkg/controller/utils/utils.go
@@ -1,0 +1,21 @@
+package utils
+
+import (
+	"fmt"
+	"math/rand"
+	"time"
+
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+)
+
+var log = logf.Log.WithName("utils_v2vvmware")
+
+const MaxRetryCount = 10
+
+func SleepBeforeRetry() {
+	rand.Seed(time.Now().Unix())
+	sleepTime := rand.Intn(5) + 3
+	log.Info(fmt.Sprintf("Falling asleep for %d seconds before retry ...", sleepTime))
+	time.Sleep(time.Second * time.Duration(sleepTime))
+	log.Info("Awake after sleep, going to retry")
+}

--- a/kubevirt-vmware/pkg/controller/v2vvmware/actions.go
+++ b/kubevirt-vmware/pkg/controller/v2vvmware/actions.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 	corev1 "k8s.io/api/core/v1"
-	kubevirtv1alpha1 "kubevirt.io/v2v-vmware/pkg/apis/kubevirt/v1alpha1"
+	kubevirtv1alpha1 "github.com/ovirt/v2v-conversion-host/kubevirt-vmware/pkg/apis/kubevirt/v1alpha1"
 	"time"
 
 	"k8s.io/apimachinery/pkg/types"

--- a/kubevirt-vmware/pkg/controller/v2vvmware/v2vvmware_controller.go
+++ b/kubevirt-vmware/pkg/controller/v2vvmware/v2vvmware_controller.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	kubevirtv1alpha1 "kubevirt.io/v2v-vmware/pkg/apis/kubevirt/v1alpha1"
+	kubevirtv1alpha1 "github.com/ovirt/v2v-conversion-host/kubevirt-vmware/pkg/apis/kubevirt/v1alpha1"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/kubevirt-vmware/pkg/controller/v2vvmware/vmware.go
+++ b/kubevirt-vmware/pkg/controller/v2vvmware/vmware.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	kubevirtv1alpha1 "kubevirt.io/v2v-vmware/pkg/apis/kubevirt/v1alpha1"
+	kubevirtv1alpha1 "github.com/ovirt/v2v-conversion-host/kubevirt-vmware/pkg/apis/kubevirt/v1alpha1"
 )
 
 /*


### PR DESCRIPTION
Affects temporary objects of following kinds:
- V2VVMWare
- Secret

There were multiple other mechanisms contemplated but this seems to be the best option for our usecase.

The garbage collector is executed in 5 minutes intervals.
Default time to live for a temporary object is 2 hours.

If needed, the time to live can be easily prolonged (recently not implemented).

Some of the constraints:
- the `deletionTimestamp` is recently for Pods only. In addition, it can not be prolonged when set
- there is no other code which can take care of it
- browser can not reliably orchestrate that