### PR TITLE
kubevirt-vmware: Delay vmware reconnection after a failure

### DIFF
--- a/kubevirt-vmware/pkg/controller/utils/utils.go
+++ b/kubevirt-vmware/pkg/controller/utils/utils.go
@@ -12,10 +12,14 @@ var log = logf.Log.WithName("utils_v2vvmware")
 
 const MaxRetryCount = 10
 
-func SleepBeforeRetry() {
+func SleepBeforeRetryN(delayBase int) {
 	rand.Seed(time.Now().Unix())
-	sleepTime := rand.Intn(5) + 3
+	sleepTime := rand.Intn(5) + delayBase
 	log.Info(fmt.Sprintf("Falling asleep for %d seconds before retry ...", sleepTime))
 	time.Sleep(time.Second * time.Duration(sleepTime))
 	log.Info("Awake after sleep, going to retry")
+}
+
+func SleepBeforeRetry() {
+	SleepBeforeRetryN(3)
 }


### PR DESCRIPTION
Makes no sense to reconnect to the VMWare immediately when
a failure occurs.

Giving up permanently makes no sense either.

Recently 15 seconds waiting period is set.