### PR TITLE
build.sh: Fix call to git describe

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,7 @@ if git describe --exact-match --tags --match "v[0-9]*" > /dev/null 2>&1 ; then
     RPM_RELEASE="1"
 else
     GIT="$(
-        git describe --always --tags --dirty=.dr |
+        git describe --always --tags --match "v[0-9]*" --dirty=.dr |
         sed -r 's/^/git/; s/^[^-]*-//; s/-g/.git/; s/-/_/g'
     )"
     RPM_RELEASE="0.$GIT.$(date -u +%Y%m%d%H%M%S)"


### PR DESCRIPTION
Fixed a call to `git describe` in `build.sh` that did not include the
`--match` argument and therefore was taking the wrong tags into
consideration.

Signed-off-by: Barak Korren <bkorren@redhat.com>
Jira-ticket: https://ovirt-jira.atlassian.net/browse/OVIRT-2690