### PR TITLE
[No Brainer] Fixed wrapper log typo

### DIFF
--- a/wrapper/virt-v2v-wrapper.py
+++ b/wrapper/virt-v2v-wrapper.py
@@ -392,7 +392,7 @@ class OSPHost(BaseHost):
             # NOTE: Do NOT use logging.exception() here as it leaks passwords
             # into the log!
             logging.error(
-                'Command exitet with non-zero return code %d, output:\n%s\n',
+                'Command exited with non-zero return code %d, output:\n%s\n',
                 e.returncode, e.output)
             return None
 


### PR DESCRIPTION
Sample output 
```
2019-03-03 02:50:01,352:ERROR: Command exitet with non-zero return code 1, output:
ConflictException: 409: Client Error for url: https://192.168.0.137:13696/v2.0/ports, {"NeutronError": {"message": "IP address 192.168.214 already allocated in subnet cdf002b5-01e7-40f3-9c0e-9127d61c9fa3", "type": "IpAddressAlreadyAllocated", "detail": ""}}
```
cc @nyoxi 