### PR TITLE
added creation of .ssh dir for vdsm

### DIFF
--- a/tasks/install-provider-rhv.yml
+++ b/tasks/install-provider-rhv.yml
@@ -1,12 +1,23 @@
 ---
 - name: Look for SSH key
   stat:
-    path: "~vdsm/.ssh/id_rsa"
+    path: "/var/lib/vdsm/.ssh/id_rsa"
   ignore_errors: "yes"
   register: stat_ssh_key
 
+- name: Create .ssh directory
+  file:
+    path: /var/lib/vdsm/.ssh
+    owner: vdsm
+    group: kvm
+    mode: 0700
+    state: present
+  become: true
+  become_user: vdsm
+  when: not stat_ssh_key.stat.exists
+
 - name: Create SSH key
-  command: ssh-keygen -b 4096 -t rsa -f ~vdsm/.ssh/id_rsa -N ''
+  command: ssh-keygen -b 4096 -t rsa -f /var/lib/vdsm/.ssh/id_rsa -N ''
   become: true
   become_user: vdsm
   when: not stat_ssh_key.stat.exists


### PR DESCRIPTION
Customer ran into following:
```
    "msg": "non-zero return code", 
    "rc": 1, 
    "start": "2019-03-21 13:04:31.231980", 
    "stderr": "Saving key \"/.ssh/id_rsa\" failed: No such file or directory", 
    "stderr_lines": [
        "Saving key \"/.ssh/id_rsa\" failed: No such file or directory"
    ], 
    "stdout": "Generating public/private rsa key pair.", 
    "stdout_lines": [
        "Generating public/private rsa key pair."
    ]
```
I then tested creating a keypair without the .ssh directory (it does not exist by default), and it fails.  Nothing in the role seems to create this directory yet either.