### PR TITLE
Added in else statement and changed print line so it's more verbose

### DIFF
--- a/wrapper/virt-v2v-wrapper.py
+++ b/wrapper/virt-v2v-wrapper.py
@@ -1533,8 +1533,10 @@ def check_rhv_version():
             (vdsm['epoch'], vdsm['version'], None),  # Ignore release number
             rpmUtils.miscutils.stringToVersion(VDSM_MIN_VERSION))
         return (res >= 0)
-    print('Minimal required oVirt/RHV version is %s' % VDSM_MIN_RHV)
-    return False
+    else:
+        print('Minimal required oVirt/RHV version is %s' % VDSM_MIN_RHV)
+        print('The current version of the host is %s' % vdsm['version'])
+        return False
 
 
 CHECKS = {


### PR DESCRIPTION
v2v wrapper is missing else statement, causing /usr/bin/virt-v2v-wrapper.py --check-rhv-version to always return false.  Also changed the print statement before false to be more verbose by adding their vdsm version.