### PR TITLE
wrapper: ignore missing disks in RHV on cleanup

### DIFF
--- a/wrapper/virt_v2v_wrapper.py
+++ b/wrapper/virt_v2v_wrapper.py
@@ -705,6 +705,11 @@ class VDSMHost(BaseHost):
                         logging.info('Removing disk id=%s', disk_id)
                         disk_service.remove()
                         disk_ids.remove(disk_id)
+                    except self.sdk.NotFoundError:
+                        logging.info('Disk id=%s does not exist (already ' +
+                                     'removed?), skipping it',
+                                     disk_id)
+                        disk_ids.remove(disk_id)
                     except self.sdk.Error:
                         logging.exception('Failed to remove disk id=%s',
                                           disk_id)

--- a/wrapper/virt_v2v_wrapper.py
+++ b/wrapper/virt_v2v_wrapper.py
@@ -708,10 +708,14 @@ class VDSMHost(BaseHost):
                     except self.sdk.Error:
                         logging.exception('Failed to remove disk id=%s',
                                           disk_id)
-                if time.time() > endt:
-                    logging.error('Timed out waiting for disks: %r', disk_ids)
-                    break
-                time.sleep(1)
+                # Avoid checking timeouts, and waiting, if there are no
+                # more disks to remove
+                if len(disk_ids) > 0:
+                    if time.time() > endt:
+                        logging.error('Timed out waiting for disks: %r',
+                                      disk_ids)
+                        break
+                    time.sleep(1)
 
     def check_install_drivers(self, data):
         """ Validate and/or find ISO with guest tools and drivers """

--- a/wrapper/virt_v2v_wrapper.py
+++ b/wrapper/virt_v2v_wrapper.py
@@ -696,7 +696,7 @@ class VDSMHost(BaseHost):
             logging.info('Removing disks: %r', disk_ids)
             endt = time.time() + TIMEOUT
             while len(disk_ids) > 0:
-                for disk_id in disk_ids:
+                for disk_id in disk_ids[:]:
                     try:
                         disk_service = disks_service.disk_service(disk_id)
                         disk = disk_service.get()


### PR DESCRIPTION
In future versions of virt-v2v, the rhv-upload output mode will remove the orphan disks on failure: 
libguestfs/libguestfs@145ae3db04a4ae973f5bc05de743bc312572b81f.
Because of this, now the wrapper will spin until the timeout when trying to remove disks on its own: since the disk does not exist, `DisksService.disk_service()` throws `NotFoundError`, which just logs the error without removing the problematic disk from the list of disks.