### PR TITLE
automation: accept build dep installation

### DIFF
--- a/automation/check-patch.sh
+++ b/automation/check-patch.sh
@@ -14,7 +14,7 @@ rpmbuild \
     -ts ./*.gz
 
 # install any build requirements
-yum-builddep output/*src.rpm
+yum-builddep -y output/*src.rpm
 
 # create the rpms
 rpmbuild \


### PR DESCRIPTION
previously yum-builddep was invoked without the "-y" option causing build failures due to deps not being installed. This patch adds the missing "-y" option.