### PR TITLE
Fix os.exists => os.path.exists

### DIFF
--- a/wrapper/virt_v2v_wrapper.py
+++ b/wrapper/virt_v2v_wrapper.py
@@ -503,7 +503,7 @@ def main():
                 os.environ['HOME'],
                 '.v2v_luks_keys_vault.json'
             )
-        if os.exists(data['luks_keys_vault']):
+        if os.path.exists(data['luks_keys_vault']):
             file_stat = os.stat(data['luks_keys_vault'])
             if file_stat.st_uid != host.get_uid():
                 hard_error('LUKS keys vault does\'nt belong to'


### PR DESCRIPTION
Otherwise the conversion fails right away. Caused by 86ba00e029a0f.

Signed-off-by: Martin Kletzander <mkletzan@redhat.com>