### PR TITLE
Fix usage of rhv-verifypeer and rhv-cafile

### DIFF
--- a/wrapper/hosts.py
+++ b/wrapper/hosts.py
@@ -767,19 +767,18 @@ class VDSMHost(BaseHost):
                 ])
 
         if 'rhv_url' in data:
+            verifypeer = str(not data['insecure_connection']).lower()
             v2v_args.extend([
                 '-o', 'rhv-upload',
                 '-oc', data['rhv_url'],
                 '-os', data['rhv_storage'],
                 '-op', data['rhv_password_file'],
-                '-oo', 'rhv-cafile=%s' % data['rhv_cafile'],
                 '-oo', 'rhv-cluster=%s' % data['rhv_cluster'],
                 '-oo', 'rhv-direct',
+                '-oo', 'rhv-verifypeer=%s' % verifypeer,
                 ])
-            if data['insecure_connection']:
-                v2v_args.extend(['-oo', 'rhv-verifypeer=%s' %
-                                ('false' if data['insecure_connection'] else
-                                 'true')])
+            if not data['insecure_connection']:
+                v2v_args.extend(['-oo', 'rhv-cafile=%s' % data['rhv_cafile']])
         elif 'export_domain' in data:
             v2v_args.extend([
                 '-o', 'rhv',

--- a/wrapper/tests/test_rhv.py
+++ b/wrapper/tests/test_rhv.py
@@ -113,9 +113,10 @@ class TestRHV(unittest.TestCase):
             '-oc', 'https://example.my-ovirt.org/ovirt-engine/api',
             '-os', 'data',
             '-op', '/rhv/password',
-            '-oo', 'rhv-cafile=/rhv/ca.pem',
             '-oo', 'rhv-cluster=Default',
             '-oo', 'rhv-direct',
+            '-oo', 'rhv-verifypeer=true',
+            '-oo', 'rhv-cafile=/rhv/ca.pem',
         ]
         host = hosts.BaseHost.factory(hosts.BaseHost.TYPE_VDSM)
         v2v_args, v2v_env = host.prepare_command(
@@ -132,7 +133,6 @@ class TestRHV(unittest.TestCase):
             '-oc', 'https://example.my-ovirt.org/ovirt-engine/api',
             '-os', 'data',
             '-op', '/rhv/password',
-            '-oo', 'rhv-cafile=/rhv/ca.pem',
             '-oo', 'rhv-cluster=Default',
             '-oo', 'rhv-direct',
             '-oo', 'rhv-verifypeer=false',


### PR DESCRIPTION
When specifying `rhv-cafile` with `rhv-verifypeer = false` the CA file is not
used, but the conversion fails if it does not exist.  Let's specify it only when
it is needed and also specify `rhv-verifypeer` always so that we're not affected
by the default being changed in virt-v2v.

Signed-off-by: Martin Kletzander <mkletzan@redhat.com>