### PR TITLE
Fix rhv-verifypeer in a compatible way

### DIFF
--- a/wrapper/hosts.py
+++ b/wrapper/hosts.py
@@ -767,6 +767,7 @@ class VDSMHost(BaseHost):
                 ])
 
         if 'rhv_url' in data:
+            verifypeer = str(not data['insecure_connection']).lower()
             v2v_args.extend([
                 '-o', 'rhv-upload',
                 '-oc', data['rhv_url'],
@@ -775,11 +776,8 @@ class VDSMHost(BaseHost):
                 '-oo', 'rhv-cafile=%s' % data['rhv_cafile'],
                 '-oo', 'rhv-cluster=%s' % data['rhv_cluster'],
                 '-oo', 'rhv-direct',
+                '-oo', 'rhv-verifypeer=%s' % verifypeer,
                 ])
-            if data['insecure_connection']:
-                v2v_args.extend(['-oo', 'rhv-verifypeer=%s' %
-                                ('false' if data['insecure_connection'] else
-                                 'true')])
         elif 'export_domain' in data:
             v2v_args.extend([
                 '-o', 'rhv',

--- a/wrapper/tests/test_rhv.py
+++ b/wrapper/tests/test_rhv.py
@@ -116,6 +116,7 @@ class TestRHV(unittest.TestCase):
             '-oo', 'rhv-cafile=/rhv/ca.pem',
             '-oo', 'rhv-cluster=Default',
             '-oo', 'rhv-direct',
+            '-oo', 'rhv-verifypeer=true',
         ]
         host = hosts.BaseHost.factory(hosts.BaseHost.TYPE_VDSM)
         v2v_args, v2v_env = host.prepare_command(


### PR DESCRIPTION
The `rhv-verifypeer` option was only supplied if `data['insecure_connection']`
was `True`.  That means if someone wanted the connection to be secure it would
not specify any argument to virt-v2v.  Unfortunately, for some reasons,
rhv-upload's `rhv-verify` parameter defaults to `false` if unspecified.  So
there is no way of making sure the certificates are validated.

To mitigate this, always specify `rhv-verifypeer` so that we do not depend on
the defaults of virt-v2v's `rhv-upload`.

Signed-off-by: Martin Kletzander <mkletzan@redhat.com>